### PR TITLE
Add PlayerSpawnVehicle check too SpawnSimfphysVehicle

### DIFF
--- a/lua/simfphys/server/spawner.lua
+++ b/lua/simfphys/server/spawner.lua
@@ -48,6 +48,8 @@ function SpawnSimfphysVehicle( Player, vname, tr )
 
 	if ( !vehicle ) then return end
 	
+	if ( !gamemode.Call( "PlayerSpawnVehicle", Player, vehicle.model, vname, vehicle ) ) then return end
+	
 	if ( !tr ) then
 		tr = Player:GetEyeTraceNoCursor()
 	end


### PR DESCRIPTION
It's called in MakeLuaVehicle but not SpawnSimfphysVehicle, so non-authorized players can still spawn vehicles with simfphys_spawnvehicle.