### PR TITLE
Wiremod integration for Turn Signals and Remaining Fuel

### DIFF
--- a/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
@@ -164,8 +164,8 @@ function ENT:createWireIO()
 	--self.Inputs = WireLib.CreateSpecialInputs(self, { "blah" }, { "NORMAL" })
 	
 	self.Outputs = WireLib.CreateSpecialOutputs( self, 
-		{ "Active","Health","RPM","Torque","DriverSeat","PassengerSeats","Driver","Gear","Ratio","Lights Enabled","Highbeams Enabled","Foglights Enabled","Sirens Enabled" },
-		{ "NORMAL","NORMAL","NORMAL","NORMAL","ENTITY","ARRAY","ENTITY","NORMAL","NORMAL","NORMAL","NORMAL","NORMAL","NORMAL" }
+		{ "Active","Health","RPM","Torque","DriverSeat","PassengerSeats","Driver","Gear","Ratio","Lights Enabled","Highbeams Enabled","Foglights Enabled","Sirens Enabled","Turn Signals Enabled","Remaining Fuel" },
+		{ "NORMAL","NORMAL","NORMAL","NORMAL","ENTITY","ARRAY","ENTITY","NORMAL","NORMAL","NORMAL","NORMAL","NORMAL","NORMAL","NORMAL","NORMAL" }
 	)
 end
 
@@ -295,6 +295,8 @@ function ENT:UpdateWireOutputs()
 	WireLib.TriggerOutput(self, "Highbeams Enabled", self:GetLampsEnabled() and 1 or 0 )
 	WireLib.TriggerOutput(self, "Foglights Enabled", self:GetFogLightsEnabled() and 1 or 0 )
 	WireLib.TriggerOutput(self, "Sirens Enabled", self:GetEMSEnabled() and 1 or 0 )
+	WireLib.TriggerOutput(self, "Turn Signals Enabled", self:GetTSEnabled())
+	WireLib.TriggerOutput(self, "Remaining Fuel", self:GetFuel())
 end
 
 function ENT:OnActiveChanged( name, old, new)

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
@@ -445,6 +445,14 @@ function ENT:ControlLighting( curtime )
 	end
 end
 
+function ENT:SetTSInternal(mode)
+	self.TSMode = mode
+end
+
+function ENT:GetTSEnabled()
+	if self.TSMode != nil then return self.TSMode else return 0 end
+end
+
 function ENT:GetEngineData()
 	local LimitRPM = math.max(self:GetLimitRPM(),4)
 	local Powerbandend = math.Clamp(self:GetPowerBandEnd(),3,LimitRPM - 1)

--- a/lua/simfphys/base_functions.lua
+++ b/lua/simfphys/base_functions.lua
@@ -112,7 +112,8 @@ if SERVER then
 		local mode = net.ReadInt( 32 ) 
 		
 		if not IsValid( ent ) then return end
-		
+		ent:SetTSInternal( mode )
+			
 		net.Start( "simfphys_turnsignal" )
 			net.WriteEntity( ent )
 			net.WriteInt( mode, 32 )

--- a/lua/simfphys/base_functions.lua
+++ b/lua/simfphys/base_functions.lua
@@ -112,7 +112,6 @@ if SERVER then
 		local mode = net.ReadInt( 32 ) 
 		
 		if not IsValid( ent ) then return end
-			
 		ent:SetTSInternal( mode )
 			
 		net.Start( "simfphys_turnsignal" )

--- a/lua/simfphys/base_functions.lua
+++ b/lua/simfphys/base_functions.lua
@@ -112,6 +112,7 @@ if SERVER then
 		local mode = net.ReadInt( 32 ) 
 		
 		if not IsValid( ent ) then return end
+			
 		ent:SetTSInternal( mode )
 			
 		net.Start( "simfphys_turnsignal" )


### PR DESCRIPTION
It's useful sometimes to have **more wiremod options**. Some of them can be exploited with a wiremod "Advanced Pod Controller" linked to the driver seat entity.

But more wiremod options are useful and cool, and do not reduce performance on their own. I know this is a little improvement but... why not?

**Feature added:**
2 new wiremod outputs:
  + **`Turn Signals Enabled`**: returns `3` if right light is activated, `2` if left light is activated, `1` if both are activated and `0` if they are disabled.
+ **`Remaining Fuel`**: returns the current amount of fuel (in liters) of the car.