### PR TITLE
Hooks

### DIFF
--- a/lua/entities/gmod_sent_vehicle_fphysics_base/damage.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/damage.lua
@@ -120,7 +120,7 @@ function ENT:ExplodeVehicle()
 			prop:Activate()
 			prop.DoNotDuplicate = true
 			bprop:DeleteOnRemove( prop )
-			bprop.Gibs[i] = prop
+			bprop.Gibs[i-1] = prop
 			
 			local PhysObj = prop:GetPhysicsObject()
 			if IsValid( PhysObj ) then

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/damage.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/damage.lua
@@ -109,6 +109,7 @@ function ENT:ExplodeVehicle()
 			ply:AddCleanup( "Gibs", bprop )
 		end
 		
+		bprop.Gibs = {}
 		for i = 2, table.Count( self.GibModels ) do
 			local prop = ents.Create( "gmod_sent_vehicle_fphysics_gib" )
 			prop:SetModel( self.GibModels[i] )			
@@ -119,6 +120,7 @@ function ENT:ExplodeVehicle()
 			prop:Activate()
 			prop.DoNotDuplicate = true
 			bprop:DeleteOnRemove( prop )
+			bprop.Gibs[i] = prop
 			
 			local PhysObj = prop:GetPhysicsObject()
 			if IsValid( PhysObj ) then
@@ -158,6 +160,7 @@ function ENT:ExplodeVehicle()
 		end
 		
 		if self.CustomWheels == true and not self.NoWheelGibs then
+			bprop.Wheels = {}
 			for i = 1, table.Count( self.GhostWheels ) do
 				local Wheel = self.GhostWheels[i]
 				if IsValid(Wheel) then
@@ -172,6 +175,7 @@ function ENT:ExplodeVehicle()
 					prop:GetPhysicsObject():SetMass( 20 )
 					prop.DoNotDuplicate = true
 					bprop:DeleteOnRemove( prop )
+					bprop.Wheels[i] = prop
 					
 					simfphys.SetOwner( ply , prop )
 				end
@@ -199,11 +203,15 @@ function ENT:ExplodeVehicle()
 	
 	self:OnDestroyed()
 	
+	hook.Run( "simfphysOnDestroyed", self, self.Gib )
+	
 	self:Remove()
 end
 
 function ENT:OnTakeDamage( dmginfo )
 	if not self:IsInitialized() then return end
+	
+	if hook.Run( "simfphysOnTakeDamage", self, dmginfo ) then return end
 	
 	local Damage = dmginfo:GetDamage() 
 	local DamagePos = dmginfo:GetDamagePosition() 
@@ -270,6 +278,9 @@ local function Spark( pos , normal , snd )
 end
 
 function ENT:PhysicsCollide( data, physobj )
+
+	if hook.Run( "simfphysPhysicsCollide", self, data, physobj ) then return end
+
 	if IsValid( data.HitEntity ) then
 		if data.HitEntity:IsNPC() or data.HitEntity:IsNextBot() or data.HitEntity:IsPlayer() then
 			Spark( data.HitPos , data.HitNormal , "MetalVehicle.ImpactSoft" )

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
@@ -801,7 +801,7 @@ end
 function ENT:StopEngine()
 	if self:EngineActive() then
 		
-		if hook.Run( "simfphysStopEngine", self ) then return end
+		if hook.Run( "simfphysOnEngine", self, false, bIgnoreSettings ) then return end
 		
 		self:EmitSound( "vehicles/jetski/jetski_off.wav" )
 
@@ -830,7 +830,7 @@ function ENT:StartEngine( bIgnoreSettings )
 	
 	if not self:EngineActive() then
 	
-		if hook.Run( "simfphysStartEngine", self, bIgnoreSettings ) then return end
+		if hook.Run( "simfphysOnEngine", self, true, bIgnoreSettings ) then return end
 		
 		if not bIgnoreSettings then
 			self.CurrentGear = 2
@@ -916,13 +916,13 @@ function ENT:SteerVehicle( steer )
 end
 
 function ENT:Lock()
-	if hook.Run( "simfphysLock", self ) then return end
+	if hook.Run( "simfphysOnLock", self, true ) then return end
 	self:SetIsVehicleLocked( true )
 	self:EmitSound( "doors/latchlocked2.wav" )
 end
 
 function ENT:UnLock()
-	if hook.Run( "simfphysUnlock", self ) then return end
+	if hook.Run( "simfphysOnLock", self, false ) then return end
 	self:SetIsVehicleLocked( false )
 	self:EmitSound( "doors/latchunlocked1.wav" )
 end

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
@@ -1002,6 +1002,8 @@ end
 
 function ENT:Use( ply )
 	if not IsValid( ply ) then return end
+	
+	if hook.Run( "simfphysUse", self, ply ) then return end
 
 	if self:GetIsVehicleLocked() or self:HasPassengerEnemyTeam( ply ) then 
 		self:EmitSound( "doors/default_locked.wav" )

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
@@ -801,7 +801,7 @@ end
 function ENT:StopEngine()
 	if self:EngineActive() then
 		
-		if hook.Run( "simfphysStopEngine", self ) return end
+		if hook.Run( "simfphysStopEngine", self ) then return end
 		
 		self:EmitSound( "vehicles/jetski/jetski_off.wav" )
 
@@ -830,7 +830,7 @@ function ENT:StartEngine( bIgnoreSettings )
 	
 	if not self:EngineActive() then
 	
-		if hook.Run( "simfphysStartEngine", self, bIgnoreSettings ) return end
+		if hook.Run( "simfphysStartEngine", self, bIgnoreSettings ) then return end
 		
 		if not bIgnoreSettings then
 			self.CurrentGear = 2

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/init.lua
@@ -55,6 +55,8 @@ function ENT:Think()
 	
 	self:OnTick()
 	
+	hook.Run( "simfphysOnTick", self )
+	
 	self.NextTick = self.NextTick or 0
 	if self.NextTick < Time then
 		self.NextTick = Time + 0.025
@@ -798,6 +800,9 @@ end
 
 function ENT:StopEngine()
 	if self:EngineActive() then
+		
+		if hook.Run( "simfphysStopEngine", self ) return end
+		
 		self:EmitSound( "vehicles/jetski/jetski_off.wav" )
 
 		self.EngineRPM = 0
@@ -824,6 +829,9 @@ function ENT:StartEngine( bIgnoreSettings )
 	if not self:CanStart() then return end
 	
 	if not self:EngineActive() then
+	
+		if hook.Run( "simfphysStartEngine", self, bIgnoreSettings ) return end
+		
 		if not bIgnoreSettings then
 			self.CurrentGear = 2
 		end
@@ -908,11 +916,13 @@ function ENT:SteerVehicle( steer )
 end
 
 function ENT:Lock()
+	if hook.Run( "simfphysLock", self ) then return end
 	self:SetIsVehicleLocked( true )
 	self:EmitSound( "doors/latchlocked2.wav" )
 end
 
 function ENT:UnLock()
+	if hook.Run( "simfphysUnlock", self ) then return end
 	self:SetIsVehicleLocked( false )
 	self:EmitSound( "doors/latchunlocked1.wav" )
 end
@@ -1330,6 +1340,7 @@ function ENT:OnRemove()
 	end
 	
 	self:OnDelete()
+	hook.Run( "simfphysOnDelete", self )
 end
 
 function ENT:PlayPP( On )
@@ -1338,6 +1349,8 @@ end
 
 function ENT:SetOnFire( bOn )
 	if bOn == self:OnFire() then return end
+	
+	if hook.Run( "simfphysOnFire", self, bOn ) then return end
 	self:SetNWBool( "OnFire", bOn )
 	
 	if bOn then
@@ -1347,6 +1360,8 @@ end
 
 function ENT:SetOnSmoke( bOn )
 	if bOn == self:OnSmoke() then return end
+	
+	if hook.Run( "simfphysOnSmoke", self, bOn ) then return end
 	self:SetNWBool( "OnSmoke", bOn )
 	
 	if bOn then

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua
@@ -47,6 +47,8 @@ end
 function ENT:SimulateAirControls(tilt_forward,tilt_back,tilt_left,tilt_right)
 	if self:IsDriveWheelsOnGround() then return end
 	
+	if hook.Run( "simfphysAirControl", tilt_forward, tilt_back, tilt_left, tilt_right) then return end
+	
 	local PObj = self:GetPhysicsObject()
 	
 	local TiltForce = ((self.Right * (tilt_right - tilt_left) * 1.8) + (self.Forward * (tilt_forward - tilt_back) * 6)) * math.acos( math.Clamp( self.Up:Dot(Vector(0,0,1)) ,-1,1) ) * (180 / math.pi) * self.Mass

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua
@@ -578,6 +578,7 @@ function ENT:SetupVehicle()
 	
 	self.EnableSuspension = 1
 	self:OnSpawn()
+	hook.Run( "simfphysOnSpawn", self )
 end
 
 function ENT:CreateWheel(index, name, attachmentpos, height, radius, swap_y , poseposition, suspensiontravel, constant, damping, rdamping)

--- a/lua/simfphys/base_functions.lua
+++ b/lua/simfphys/base_functions.lua
@@ -79,6 +79,8 @@ hook.Add( "simfphysStopEngine", "simf_hook_stopengine", function() end )
 hook.Add( "simfphysAirControl", "simf_hook_aircontrol", function() end )
 --full repair hook (called by repair tool only)
 hook.Add( "simfphysOnRepair", "simf_hook_onrepair", function() end )
+--use hook (return true to disable)
+hook.Add( "simfphysUse", "simf_hook_use", function() end )
 
 function simfphys.IsCar( ent )
 	if not IsValid( ent ) then return false end

--- a/lua/simfphys/base_functions.lua
+++ b/lua/simfphys/base_functions.lua
@@ -57,31 +57,6 @@ simfphys.gravel = CreateConVar( "sv_simfphys_traction_gravel", "1", {FCVAR_REPLI
 simfphys.rock = CreateConVar( "sv_simfphys_traction_rock", "1", {FCVAR_REPLICATED , FCVAR_ARCHIVE})
 simfphys.wood = CreateConVar( "sv_simfphys_traction_wood", "1", {FCVAR_REPLICATED , FCVAR_ARCHIVE})
 
---spawn and tick hooks
-hook.Add( "simfphysOnSpawn", "simf_hook_spawn", function() end )
-hook.Add( "simfphysOnTick", "simf_hook_tick", function() end )
---delete and destroyed hooks
-hook.Add( "simfphysOnDelete", "simf_hook_delete", function() end )
-hook.Add( "simfphysOnDestroyed", "simf_hook_destroyed", function() end )
---damage hooks (return true to disable)
-hook.Add( "simfphysOnTakeDamage", "simf_hook_ontakedamage", function() end )
-hook.Add( "simfphysPhysicsCollide", "simf_hook_physicscollide", function() end )
---fire and smoke hooks (return true to disable)
-hook.Add( "simfphysOnFire", "simf_hook_onfire", function() end )
-hook.Add( "simfphysOnSmoke", "simf_hook_onsmoke", function() end )
---lock and unlock hooks (return true to disable)
-hook.Add( "simfphysLock", "simf_hook_lock", function() end )
-hook.Add( "simfphysUnlock", "simf_hook_unlock", function() end )
---engine start and stop hooks (return true to disable)
-hook.Add( "simfphysStartEngine", "simf_hook_startengine", function() end )
-hook.Add( "simfphysStopEngine", "simf_hook_stopengine", function() end )
---air control hook (return true to disable)
-hook.Add( "simfphysAirControl", "simf_hook_aircontrol", function() end )
---full repair hook (called by repair tool only)
-hook.Add( "simfphysOnRepair", "simf_hook_onrepair", function() end )
---use hook (return true to disable)
-hook.Add( "simfphysUse", "simf_hook_use", function() end )
-
 function simfphys.IsCar( ent )
 	if not IsValid( ent ) then return false end
 	

--- a/lua/simfphys/base_functions.lua
+++ b/lua/simfphys/base_functions.lua
@@ -57,6 +57,29 @@ simfphys.gravel = CreateConVar( "sv_simfphys_traction_gravel", "1", {FCVAR_REPLI
 simfphys.rock = CreateConVar( "sv_simfphys_traction_rock", "1", {FCVAR_REPLICATED , FCVAR_ARCHIVE})
 simfphys.wood = CreateConVar( "sv_simfphys_traction_wood", "1", {FCVAR_REPLICATED , FCVAR_ARCHIVE})
 
+--spawn and tick hooks
+hook.Add( "simfphysOnSpawn", "simf_hook_spawn", function() end )
+hook.Add( "simfphysOnTick", "simf_hook_tick", function() end )
+--delete and destroyed hooks
+hook.Add( "simfphysOnDelete", "simf_hook_delete", function() end )
+hook.Add( "simfphysOnDestroyed", "simf_hook_destroyed", function() end )
+--damage hooks (return true to disable)
+hook.Add( "simfphysOnTakeDamage", "simf_hook_ontakedamage", function() end )
+hook.Add( "simfphysPhysicsCollide", "simf_hook_physicscollide", function() end )
+--fire and smoke hooks (return true to disable)
+hook.Add( "simfphysOnFire", "simf_hook_onfire", function() end )
+hook.Add( "simfphysOnSmoke", "simf_hook_onsmoke", function() end )
+--lock and unlock hooks (return true to disable)
+hook.Add( "simfphysLock", "simf_hook_lock", function() end )
+hook.Add( "simfphysUnlock", "simf_hook_unlock", function() end )
+--engine start and stop hooks (return true to disable)
+hook.Add( "simfphysStartEngine", "simf_hook_startengine", function() end )
+hook.Add( "simfphysStopEngine", "simf_hook_stopengine", function() end )
+--air control hook (return true to disable)
+hook.Add( "simfphysAirControl", "simf_hook_aircontrol", function() end )
+--full repair hook (called by repair tool only)
+hook.Add( "simfphysOnRepair", "simf_hook_onrepair", function() end )
+
 function simfphys.IsCar( ent )
 	if not IsValid( ent ) then return false end
 	


### PR DESCRIPTION
#### A bunch of hooks to hopefully make addon makers stop using hacky workarounds to add their own functionality to vehicles.

Currently, the only way to add or replace functionality on vehicles is to replace the function after the vehicle has spawned with a hook. That means things have a high chance of conflicting with other addons or breaking with updates. 
An example of a simfphys update breaking a hacky patch is my vFire "support" addon that once broke after an update to how OnFire() was handled. 

[Example of replacing functions.](https://github.com/NotAKidOnSteam/simfphys-bodygroup-hitboxes/blob/6a0da7d9a8d4624eba0bc206304f3a69af40648a/lua/notakid/hitboxes/init.lua#L269)

With proper hook support, it means addons like my vFire support mod or other mods that add functionality to simfphys vehicles no longer can conflict with each other and won't have any issues with simfphys updates in the future.
This should also give server owners enough control over simfphys vehicles that they don't need to modify it as much or upload their own versions to the workshop.

### Added hooks:
- simfphysOnSpawn
- simfphysOnTick
- simfphysOnDelete
- simfphysOnDestroyed
- simfphysOnTakeDamage
- simfphysPhysicsCollide
- simfphysOnFire
- simfphysOnSmoke
- simfphysOnLock
- simfphysOnEngine
- simfphysAirControl
- simfphysOnRepair
- simfphysUse

### Examples of adding functionality with a hook:
```lua
        --adds explosion knockback to simfphys vehicles
	hook.Add( "simfphysOnTakeDamage", "Simfphys_Tweaks_Mod", function( ent, dmginfo )
		if dmginfo:IsExplosionDamage() then
			local modifier = 2000
			local maxmodifier = 1000
			--probably not the most performant..
			local tr = util.TraceLine( {
				start = dmginfo:GetDamagePosition(),
				endpos = ent:GetPos(),
				filter = function( hitent ) if hitent == ent then return true end end
			} )
			local phys = ent:GetPhysicsObject()
			local force = math.Clamp(dmginfo:GetDamage()*modifier, 0, phys:GetMass()*maxmodifier)
			phys:ApplyForceOffset(tr.Normal*force, tr.HitPos )
		end
	end )
```
```lua
        --applies proxy colors from the vehicle to the gib as base simfphys does not support it
	hook.Add( "simfphysOnDestroyed", "Simfphys_Tweaks_Mod", function( ent, gib )
	        if ProxyColor then
		        local prxyclr = ent:GetProxyColor()
		        gib:SetProxyColor( prxyclr )
                end
	end )
```
from https://github.com/Blu-x92/simfphys_base/issues/49
```lua
        --turbo blow-off
	local gear = 0
	local gearNext = 0
	hook.Add("simfphysOnTick", "Simfphys_Tweaks_Mod", function(ent)
		gearNext = ent:GetGear()
		if (gear ~= gearNext) then
			ent:SetThrottle(0)
		end
		gear = ent:GetGear()
	end)
```

These are just quick examples of things that can be done with these hooks. I am sure some more talented people can come up with much better uses for them. 