### PR TITLE
Prevent headlight press timer from causing errors

### DIFF
--- a/lua/entities/gmod_sent_vehicle_fphysics_base/numpads.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/numpads.lua
@@ -262,7 +262,7 @@ numpad.Register( "k_lgts", function( pl, ent, keydown )
 	if keydown then
 		ent.KeyPressedTime = Time
 	else
-		if (Time - ent.KeyPressedTime) >= (ent.LightsActivated and 0.22 or 0) then
+		if ent.KeyPressedTime and (Time - ent.KeyPressedTime) >= (ent.LightsActivated and 0.22 or 0) then
 			if (ent.NextLightCheck or 0) > Time then return end
 			
 			local vehiclelist = list.Get( "simfphys_lights" )[ent.LightsTable] or false


### PR DESCRIPTION
Sometimes entering a vehicle with the +use button bound to F and the simfphys lights key bound to F raises a scripting error without an indication as to a cause.
This is probably not the only occasion where this occurs, but it is the most easily reproducible situation, it also helps to be a new vehicle during the start of a new session.

Tested against the latest workshop version, I found that inserting this on line 259 prevents raising an error on the first time entering a vehicle:
```md
if not ent.KeyPressedTime then
    print("got the bastard")
    print(ent)
    return false
end
```

However, the proposed change is a little more elegant.