### PR TITLE
changed rendermode from transalpha to normal

### DIFF
--- a/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua
@@ -4,7 +4,7 @@ function ENT:Initialize()
 	self:SetSolid( SOLID_VPHYSICS )
 	self:SetNotSolid( true )
 	self:SetUseType( SIMPLE_USE )
-	self:SetRenderMode( RENDERMODE_TRANSALPHA )
+	self:SetRenderMode( RENDERMODE_NORMAL )
 	self:AddFlags( FL_OBJECT ) -- this allows npcs to see this entity
 
 	local PObj = self:GetPhysicsObject()


### PR DESCRIPTION
fixes decals not appearing on simfphys vehicles like bullets, blood, paint, ect

Unsure if there is a technical reason it was set to transalpha, so if there is please let me know.