### PR TITLE
Return early on invalid self

### DIFF
--- a/lua/weapons/weapon_simfillerpistol.lua
+++ b/lua/weapons/weapon_simfillerpistol.lua
@@ -316,6 +316,7 @@ function SWEP:PrimaryAttack()
 						ent:SetFuel( Fuel + self.RefilAmount )
 					
 						timer.Simple(0.2, function()
+                            if not IsValid( self ) or not IsValid( Owner ) then return end
 							if self:GetFuelType() == FUELTYPE_ELECTRIC then
 								sound.Play( Sound( "items/battery_pickup.wav" ), Trace.HitPos, 50)
 								

--- a/lua/weapons/weapon_simfillerpistol.lua
+++ b/lua/weapons/weapon_simfillerpistol.lua
@@ -316,7 +316,7 @@ function SWEP:PrimaryAttack()
 						ent:SetFuel( Fuel + self.RefilAmount )
 					
 						timer.Simple(0.2, function()
-                            if not IsValid( self ) or not IsValid( Owner ) then return end
+							if not IsValid( self ) or not IsValid( Owner ) then return end
 							if self:GetFuelType() == FUELTYPE_ELECTRIC then
 								sound.Play( Sound( "items/battery_pickup.wav" ), Trace.HitPos, 50)
 								


### PR DESCRIPTION
Prevents the error:
```
lua/weapons/weapon_simfillerpistol.lua:319: attempt to call method 'GetFuelType' (a nil value)
   1.  GetFuelType - [C]:-1
    2.  unknown - lua/weapons/weapon_simfillerpistol.lua:319
```