### PR TITLE
Add IsValid check for ghostwheels

### DIFF
--- a/lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua
@@ -408,18 +408,18 @@ function ENT:SimulateWheels(k_clutch,LimitRPM)
 			
 			if self.CustomWheels then
 				local GhostEnt = self.GhostWheels[i]
-                if IsValid(GhostEnt) then
-                    local Angle = GhostEnt:GetAngles()
-                    local offsetang = WheelPos.IsFrontWheel and self.CustomWheelAngleOffset or (self.CustomWheelAngleOffset_R or self.CustomWheelAngleOffset)
-                    local Direction = GhostEnt:LocalToWorldAngles( offsetang ):Forward()
-                    local TFront = FrontWheelCanTurn and TurnWheel or 0
-                    local TBack = RearWheelCanTurn and TurnWheel or 0
-                    
-                    local AngleStep = WheelPos.IsFrontWheel and TFront or TBack
-                    Angle:RotateAroundAxis(Direction, WheelPos.IsRightWheel and AngleStep or -AngleStep)
-                    
-                    GhostEnt:SetAngles( Angle )
-                end
+				if IsValid(GhostEnt) then
+					local Angle = GhostEnt:GetAngles()
+					local offsetang = WheelPos.IsFrontWheel and self.CustomWheelAngleOffset or (self.CustomWheelAngleOffset_R or self.CustomWheelAngleOffset)
+					local Direction = GhostEnt:LocalToWorldAngles( offsetang ):Forward()
+					local TFront = FrontWheelCanTurn and TurnWheel or 0
+					local TBack = RearWheelCanTurn and TurnWheel or 0
+					
+					local AngleStep = WheelPos.IsFrontWheel and TFront or TBack
+					Angle:RotateAroundAxis(Direction, WheelPos.IsRightWheel and AngleStep or -AngleStep)
+					
+					GhostEnt:SetAngles( Angle )
+				end
 			else
 				self:SetPoseParameter(self.VehicleData[ "pp_spin_" .. i ],self.VehicleData[ "spin_" .. i ]) 
 			end

--- a/lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua
@@ -408,16 +408,18 @@ function ENT:SimulateWheels(k_clutch,LimitRPM)
 			
 			if self.CustomWheels then
 				local GhostEnt = self.GhostWheels[i]
-				local Angle = GhostEnt:GetAngles()
-				local offsetang = WheelPos.IsFrontWheel and self.CustomWheelAngleOffset or (self.CustomWheelAngleOffset_R or self.CustomWheelAngleOffset)
-				local Direction = GhostEnt:LocalToWorldAngles( offsetang ):Forward()
-				local TFront = FrontWheelCanTurn and TurnWheel or 0
-				local TBack = RearWheelCanTurn and TurnWheel or 0
-				
-				local AngleStep = WheelPos.IsFrontWheel and TFront or TBack
-				Angle:RotateAroundAxis(Direction, WheelPos.IsRightWheel and AngleStep or -AngleStep)
-				
-				self.GhostWheels[i]:SetAngles( Angle )
+                if IsValid(GhostEnt) then
+                    local Angle = GhostEnt:GetAngles()
+                    local offsetang = WheelPos.IsFrontWheel and self.CustomWheelAngleOffset or (self.CustomWheelAngleOffset_R or self.CustomWheelAngleOffset)
+                    local Direction = GhostEnt:LocalToWorldAngles( offsetang ):Forward()
+                    local TFront = FrontWheelCanTurn and TurnWheel or 0
+                    local TBack = RearWheelCanTurn and TurnWheel or 0
+                    
+                    local AngleStep = WheelPos.IsFrontWheel and TFront or TBack
+                    Angle:RotateAroundAxis(Direction, WheelPos.IsRightWheel and AngleStep or -AngleStep)
+                    
+                    GhostEnt:SetAngles( Angle )
+                end
 			else
 				self:SetPoseParameter(self.VehicleData[ "pp_spin_" .. i ],self.VehicleData[ "spin_" .. i ]) 
 			end


### PR DESCRIPTION
Fixes a frequent error.
![image](https://github.com/Blu-x92/simfphys_base/assets/69946827/1cefd678-ae35-4bf0-b909-f709d4571eda)

Error:
```
lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua:411: Tried to use a NULL entity!
   1.  unknown - [C]:-1
    2.  GetAngles - [C]:-1
     3.  SimulateWheels - lua/entities/gmod_sent_vehicle_fphysics_base/simfunc.lua:411
      4.  SimulateVehicle - lua/entities/gmod_sent_vehicle_fphysics_base/init.lua:577
       5.  unknown - lua/entities/gmod_sent_vehicle_fphysics_base/init.lua:131
```

Locals of the error:
```lua
Velocity             = Vector [-0.06, 0, 0]
self                 = Entity [1646][gmod_sent_vehicle_fphysics_base]
RearWheelCanTurn     = Bool [true]
TurnWheel            = Number [-0.01]
Right                = Vector [0.2, -0.98, 0.1]
WheelPos             = {
  IsFrontWheel = Bool [true]
  IsRightWheel = Bool [false]
}
TractionCycle        = Number [0.01]
BrakeForce           = Number [0]
```