### PR TITLE
Fix mouse steer net spam

### DIFF
--- a/lua/simfphys/client/hud.lua
+++ b/lua/simfphys/client/hud.lua
@@ -98,9 +98,6 @@ ms_deadzone = GetConVar( "cl_simfphys_ms_deadzone" ):GetFloat()
 ms_exponent = GetConVar( "cl_simfphys_ms_exponent" ):GetFloat()
 ms_key_freelook = GetConVar( "cl_simfphys_ms_keyfreelook" ):GetInt()
 
-local ms_pos_x = 0
-local sm_throttle = 0
-
 local function DrawCircle( X, Y, radius )
 	local segmentdist = 360 / ( 2 * math.pi * radius / 2 )
 	
@@ -108,6 +105,11 @@ local function DrawCircle( X, Y, radius )
 		surface.DrawLine( X + math.cos( math.rad( a ) ) * radius, Y - math.sin( math.rad( a ) ) * radius, X + math.cos( math.rad( a + segmentdist ) ) * radius, Y - math.sin( math.rad( a + segmentdist ) ) * radius )
 	end
 end
+
+local ms_pos_x = 0
+local sm_throttle = 0
+local s_smoothrpm = 0
+local lastMouseSteer = 0
 
 hook.Add( "StartCommand", "simfphysmove", function( ply, cmd )
 	if ply ~= LocalPlayer() then return end
@@ -132,11 +134,14 @@ hook.Add( "StartCommand", "simfphysmove", function( ply, cmd )
 
 	end
 
+	if lastMouseSteer == SteerVehicle then return end
+	lastMouseSteer = SteerVehicle
+
 	net.Start( "simfphys_mousesteer" )
 		net.WriteEntity( vehicle )
-		net.WriteFloat( SteerVehicle )
+		net.WriteInt( SteerVehicle * 255, 9 )
 	net.SendToServer()
-end)
+end )
 
 local function drawsimfphysHUD(vehicle,SeatCount)
 	if isMouseSteer and ShowHud_ms then

--- a/lua/simfphys/client/hud.lua
+++ b/lua/simfphys/client/hud.lua
@@ -56,7 +56,6 @@ cvars.AddChangeCallback( "cl_simfphys_althud_arcs", function( convar, oldValue, 
 cvars.AddChangeCallback( "cl_simfphys_hudmph", function( convar, oldValue, newValue ) Hudmph = tonumber( newValue )~=0 end)
 cvars.AddChangeCallback( "cl_simfphys_hudmpg", function( convar, oldValue, newValue ) Hudmpg = tonumber( newValue )~=0 end)
 cvars.AddChangeCallback( "cl_simfphys_hudrealspeed", function( convar, oldValue, newValue ) Hudreal = tonumber( newValue )~=0 end)
-cvars.AddChangeCallback( "cl_simfphys_mousesteer", function( convar, oldValue, newValue ) isMouseSteer = tonumber( newValue )~=0 end)
 cvars.AddChangeCallback( "cl_simfphys_ctenable", function( convar, oldValue, newValue ) hasCounterSteerEnabled = tonumber( newValue )~=0 end)
 cvars.AddChangeCallback( "cl_simfphys_auto", function( convar, oldValue, newValue ) slushbox = tonumber( newValue )~=0 end)
 cvars.AddChangeCallback( "cl_simfphys_ms_sensitivity", function( convar, oldValue, newValue )  ms_sensitivity = tonumber( newValue ) end)
@@ -65,6 +64,19 @@ cvars.AddChangeCallback( "cl_simfphys_ms_deadzone", function( convar, oldValue, 
 cvars.AddChangeCallback( "cl_simfphys_ms_exponent", function( convar, oldValue, newValue ) ms_exponent = tonumber( newValue ) end)
 cvars.AddChangeCallback( "cl_simfphys_ms_keyfreelook", function( convar, oldValue, newValue ) ms_key_freelook = tonumber( newValue ) end)
 cvars.AddChangeCallback( "cl_simfphys_key_turnmenu", function( convar, oldValue, newValue ) turnmenu = tonumber( newValue ) end)
+cvars.AddChangeCallback( "cl_simfphys_mousesteer", function( convar, oldValue, newValue )
+	local new = tonumber( newValue )
+	isMouseSteer = new ~= 0
+	if new ~= 0 then return end
+
+	local veh = LocalPlayer():GetVehicle()
+	if not IsValid( veh ) then return end
+
+	net.Start( "simfphys_mousesteer" )
+	net.WriteEntity( veh )
+	net.WriteFloat( 0 )
+	net.SendToServer()
+end )
 
 ShowHud = GetConVar( "cl_simfphys_hud" ):GetBool()
 hudoffset_x = GetConVar( "cl_simfphys_hud_offset_x" ):GetFloat()
@@ -99,30 +111,27 @@ end
 
 hook.Add( "StartCommand", "simfphysmove", function( ply, cmd )
 	if ply ~= LocalPlayer() then return end
-	
+	if not isMouseSteer then return end
+
 	local vehicle = ply:GetVehicle()
-	if not IsValid(vehicle) then return end
-	
-	if isMouseSteer then
-		local freelook = input.IsButtonDown( ms_key_freelook )
-		ply.Freelook = freelook
-		if not freelook then 
-			local frametime = FrameTime()
-			
-			local ms_delta_x = cmd:GetMouseX()
-			local ms_return = ms_fade * frametime
-			
-			local Moving = math.abs(ms_delta_x) > 0
-			
-			ms_pos_x = Moving and math.Clamp(ms_pos_x + ms_delta_x * frametime * 0.05 * ms_sensitivity,-1,1) or (ms_pos_x + math.Clamp(-ms_pos_x,-ms_return,ms_return))
-			
-			SteerVehicle = ((math.max( math.abs(ms_pos_x) - ms_deadzone / 16, 0) ^ ms_exponent) / (1 - ms_deadzone / 16))  * ((ms_pos_x > 0) and 1 or -1)
-			
-		end
-	else
-		SteerVehicle = 0
+	if not IsValid( vehicle ) then return end
+
+	local freelook = input.IsButtonDown( ms_key_freelook )
+	ply.Freelook = freelook
+	if not freelook then
+		local frametime = FrameTime()
+
+		local ms_delta_x = cmd:GetMouseX()
+		local ms_return = ms_fade * frametime
+
+		local Moving = math.abs(ms_delta_x) > 0
+
+		ms_pos_x = Moving and math.Clamp(ms_pos_x + ms_delta_x * frametime * 0.05 * ms_sensitivity,-1,1) or (ms_pos_x + math.Clamp(-ms_pos_x,-ms_return,ms_return))
+
+		SteerVehicle = ((math.max( math.abs(ms_pos_x) - ms_deadzone / 16, 0) ^ ms_exponent) / (1 - ms_deadzone / 16))  * ((ms_pos_x > 0) and 1 or -1)
+
 	end
-	
+
 	net.Start( "simfphys_mousesteer" )
 		net.WriteEntity( vehicle )
 		net.WriteFloat( SteerVehicle )

--- a/lua/simfphys/server/seatcontrols.lua
+++ b/lua/simfphys/server/seatcontrols.lua
@@ -1,16 +1,18 @@
 util.AddNetworkString( "simfphys_mousesteer" )
 util.AddNetworkString( "simfphys_blockcontrols" )
 	
-net.Receive( "simfphys_mousesteer", function( length, ply )
+net.Receive( "simfphys_mousesteer", function( _, ply )
 	if not ply:IsDrivingSimfphys() then return end
 
 	local vehicle = net.ReadEntity()
-	local Steer = net.ReadFloat()
-	
+	local Steer = net.ReadInt( 9 )
+
+	Steer = Steer / 255
+
 	if not IsValid( vehicle ) or ply:GetSimfphys() ~= vehicle:GetParent() then return end
-	
+
 	vehicle.ms_Steer = Steer
-end)
+end )
 
 net.Receive( "simfphys_blockcontrols", function( length, ply )
 	if not IsValid( ply ) then return end


### PR DESCRIPTION
Currently, 0 is send every client frame even if `cl_simfphys_mousesteer` is set to 0. This isn't needed as the server only needs a single 0 to reset steering. So instead of constantly sending it this PR makes it so it sends a net message only once.

I noticed that this was an issue after seeing simfphys sending millions of net messages.
![image](https://github.com/Blu-x92/simfphys_base/assets/69946827/df0635ce-dc9c-4941-a582-64608bc9af9c)
